### PR TITLE
Remote state Locking feature & gitignore file added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.terraform/*
+.terraform.lock.hcl
+crash.log
+*.txt

--- a/remote_backend.tf
+++ b/remote_backend.tf
@@ -3,6 +3,6 @@ terraform {
     bucket = "tfstate-remote-backend"
     key    = "pet_infra-remote.tfstate"
     region = "us-west-2"
-    # dynamodb_table = "remote-tfstate-lock"
+    dynamodb_table = "remote-tfstate-lock"
   }
 }


### PR DESCRIPTION
1: Now the remote state lock has been achieved using DynamoDB's Table
Refer: https://www.terraform.io/docs/language/settings/backends/s3.html#dynamodb-state-locking

2: Added GIT Ignore files which will be always there but not needed to track in the project so more cleaned "git status" can be seen.
Refer: https://git-scm.com/docs/gitignore